### PR TITLE
Update nullable types for PHP 8.4

### DIFF
--- a/src/voku/helper/UTF8.php
+++ b/src/voku/helper/UTF8.php
@@ -1621,7 +1621,7 @@ final class UTF8
     public static function extract_text(
         string $str,
         string $search = '',
-        int $length = null,
+        ?int $length = null,
         string $replacer_for_skipped_text = '…',
         string $encoding = 'UTF-8'
     ): string {
@@ -1842,8 +1842,8 @@ final class UTF8
         string $filename,
         bool $use_include_path = false,
         $context = null,
-        int $offset = null,
-        int $max_length = null,
+        ?int $offset = null,
+        ?int $max_length = null,
         int $timeout = 10,
         bool $convert_to_utf8 = true,
         string $from_encoding = ''
@@ -2576,7 +2576,7 @@ final class UTF8
      *               return bool-value, if $key is used and available<br>
      *               otherwise return <strong>null</strong>
      */
-    public static function getSupportInfo(string $key = null)
+    public static function getSupportInfo(?string $key = null)
     {
         if ($key === null) {
             return self::$SUPPORT;
@@ -3027,7 +3027,7 @@ final class UTF8
      */
     public static function html_entity_decode(
         string $str,
-        int $flags = null,
+        ?int $flags = null,
         string $encoding = 'UTF-8'
     ): string {
         if (
@@ -4301,7 +4301,7 @@ final class UTF8
         string $str,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false,
-        string $lang = null,
+        ?string $lang = null,
         bool $try_to_keep_the_string_length = false
     ): string {
         if ($clean_utf8) {
@@ -4367,7 +4367,7 @@ final class UTF8
         string $char_list = '',
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false,
-        string $lang = null,
+        ?string $lang = null,
         bool $try_to_keep_the_string_length = false
     ): string {
         if (!$str) {
@@ -4440,7 +4440,7 @@ final class UTF8
      *
      * @return string the string with unwanted characters stripped from the left
      */
-    public static function ltrim(string $str = '', string $chars = null): string
+    public static function ltrim(string $str = '', ?string $chars = null): string
     {
         if ($str === '') {
             return '';
@@ -5621,7 +5621,7 @@ final class UTF8
      * @return string
      *                <p>A string with unwanted characters stripped from the right.</p>
      */
-    public static function rtrim(string $str = '', string $chars = null): string
+    public static function rtrim(string $str = '', ?string $chars = null): string
     {
         if ($str === '') {
             return '';
@@ -5762,7 +5762,7 @@ final class UTF8
         string $str,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false,
-        string $lang = null,
+        ?string $lang = null,
         bool $try_to_keep_the_string_length = false
     ): string {
         if ($clean_utf8) {
@@ -6023,7 +6023,7 @@ final class UTF8
         string $delimiter,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false,
-        string $lang = null,
+        ?string $lang = null,
         bool $try_to_keep_the_string_length = false
     ): string {
         if (self::$SUPPORT['mbstring'] === true) {
@@ -7678,7 +7678,7 @@ final class UTF8
         $search,
         $replace,
         $subject,
-        int &$count = null
+        ?int &$count = null
     ) {
         /**
          * @psalm-suppress PossiblyNullArgument
@@ -7912,7 +7912,7 @@ final class UTF8
     public static function str_slice(
         string $str,
         int $start,
-        int $end = null,
+        ?int $end = null,
         string $encoding = 'UTF-8'
     ) {
         if ($encoding === 'UTF-8') {
@@ -8701,13 +8701,13 @@ final class UTF8
      */
     public static function str_titleize(
         string $str,
-        array $ignore = null,
+        ?array $ignore = null,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false,
-        string $lang = null,
+        ?string $lang = null,
         bool $try_to_keep_the_string_length = false,
         bool $use_trim_first = true,
-        string $word_define_chars = null
+        ?string $word_define_chars = null
     ): string {
         if ($str === '') {
             return '';
@@ -9059,7 +9059,7 @@ final class UTF8
      *
      * @return string[]
      */
-    public static function str_to_lines(string $str, bool $remove_empty_values = false, int $remove_short_values = null): array
+    public static function str_to_lines(string $str, bool $remove_empty_values = false, ?int $remove_short_values = null): array
     {
         if ($str === '') {
             return $remove_empty_values ? [] : [''];
@@ -9110,7 +9110,7 @@ final class UTF8
         string $str,
         string $char_list = '',
         bool $remove_empty_values = false,
-        int $remove_short_values = null
+        ?int $remove_short_values = null
     ): array {
         if ($str === '') {
             return $remove_empty_values ? [] : [''];
@@ -9351,7 +9351,7 @@ final class UTF8
         string $str,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false,
-        string $lang = null,
+        ?string $lang = null,
         bool $try_to_keep_the_string_length = false
     ): string {
         return self::ucfirst(self::str_camelize($str, $encoding), $encoding, $clean_utf8, $lang, $try_to_keep_the_string_length);
@@ -9514,7 +9514,7 @@ final class UTF8
         string $str,
         string $char_list,
         int $offset = 0,
-        int $length = null,
+        ?int $length = null,
         string $encoding = 'UTF-8'
     ): int {
         if ($encoding !== 'UTF-8' && $encoding !== 'CP850') {
@@ -9649,7 +9649,7 @@ final class UTF8
      */
     public static function strip_tags(
         string $str,
-        string $allowable_tags = null,
+        ?string $allowable_tags = null,
         bool $clean_utf8 = false
     ): string {
         if ($str === '') {
@@ -11117,7 +11117,7 @@ final class UTF8
         string $str,
         string $mask,
         int $offset = 0,
-        int $length = null,
+        ?int $length = null,
         string $encoding = 'UTF-8'
     ) {
         if ($encoding !== 'UTF-8' && $encoding !== 'CP850') {
@@ -11348,7 +11348,7 @@ final class UTF8
         bool $full = true,
         bool $clean_utf8 = false,
         string $encoding = 'UTF-8',
-        string $lang = null,
+        ?string $lang = null,
         bool $lower = true
     ): string {
         if ($str === '') {
@@ -11402,7 +11402,7 @@ final class UTF8
         $str,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false,
-        string $lang = null,
+        ?string $lang = null,
         bool $try_to_keep_the_string_length = false
     ): string {
         // init
@@ -11482,7 +11482,7 @@ final class UTF8
         $str,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false,
-        string $lang = null,
+        ?string $lang = null,
         bool $try_to_keep_the_string_length = false
     ): string {
         // init
@@ -11696,7 +11696,7 @@ final class UTF8
     public static function substr(
         string $str,
         int $offset = 0,
-        int $length = null,
+        ?int $length = null,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false
     ) {
@@ -11867,7 +11867,7 @@ final class UTF8
         string $str1,
         string $str2,
         int $offset = 0,
-        int $length = null,
+        ?int $length = null,
         bool $case_insensitivity = false,
         string $encoding = 'UTF-8'
     ): int {
@@ -11925,7 +11925,7 @@ final class UTF8
         string $haystack,
         string $needle,
         int $offset = 0,
-        int $length = null,
+        ?int $length = null,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false
     ) {
@@ -12017,7 +12017,7 @@ final class UTF8
         string $haystack,
         string $needle,
         int $offset = 0,
-        int $length = null
+        ?int $length = null
     ) {
         if ($haystack === '' || $needle === '') {
             return 0;
@@ -12167,7 +12167,7 @@ final class UTF8
      *                      <i>length</i> parameters.</p><p>If <i>str</i> is shorter than <i>offset</i>
      *                      characters long, <b>FALSE</b> will be returned.</p>
      */
-    public static function substr_in_byte(string $str, int $offset = 0, int $length = null)
+    public static function substr_in_byte(string $str, int $offset = 0, ?int $length = null)
     {
         // empty string
         if ($str === '' || $length === 0) {
@@ -12565,7 +12565,7 @@ final class UTF8
         string $str,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false,
-        string $lang = null,
+        ?string $lang = null,
         bool $try_to_keep_the_string_length = false
     ): string {
         if ($clean_utf8) {
@@ -12972,7 +12972,7 @@ final class UTF8
      * @return string
      *                <p>The trimmed string.</p>
      */
-    public static function trim(string $str = '', string $chars = null): string
+    public static function trim(string $str = '', ?string $chars = null): string
     {
         if ($str === '') {
             return '';
@@ -13022,7 +13022,7 @@ final class UTF8
         string $str,
         string $encoding = 'UTF-8',
         bool $clean_utf8 = false,
-        string $lang = null,
+        ?string $lang = null,
         bool $try_to_keep_the_string_length = false
     ): string {
         if ($str === '') {
@@ -13490,7 +13490,7 @@ final class UTF8
         string $break = "\n",
         bool $cut = false,
         bool $add_final_break = true,
-        string $delimiter = null
+        ?string $delimiter = null
     ): string {
         if ($delimiter === null) {
             $strings = \preg_split('/\\r\\n|\\r|\\n/', $str);
@@ -13817,7 +13817,7 @@ final class UTF8
     private static function reduce_string_array(
         array $strings,
         bool $remove_empty_values,
-        int $remove_short_values = null
+        ?int $remove_short_values = null
     ) {
         // init
         $return = [];


### PR DESCRIPTION
Upsteam PR https://github.com/voku/portable-utf8/pull/208

Fixes
```
Deprecated: voku\helper\UTF8::extract_text(): Implicitly marking parameter $length as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 1622

Deprecated: voku\helper\UTF8::file_get_contents(): Implicitly marking parameter $offset as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 1842

Deprecated: voku\helper\UTF8::file_get_contents(): Implicitly marking parameter $max_length as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 1842

Deprecated: voku\helper\UTF8::getSupportInfo(): Implicitly marking parameter $key as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 2580

Deprecated: voku\helper\UTF8::html_entity_decode(): Implicitly marking parameter $flags as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 3029

Deprecated: voku\helper\UTF8::lcfirst(): Implicitly marking parameter $lang as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 4301

Deprecated: voku\helper\UTF8::lcwords(): Implicitly marking parameter $lang as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 4365

Deprecated: voku\helper\UTF8::ltrim(): Implicitly marking parameter $chars as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 4444

Deprecated: voku\helper\UTF8::rtrim(): Implicitly marking parameter $chars as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 5625

Deprecated: voku\helper\UTF8::str_camelize(): Implicitly marking parameter $lang as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 5762

Deprecated: voku\helper\UTF8::str_delimit(): Implicitly marking parameter $lang as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 6022

Deprecated: voku\helper\UTF8::str_replace(): Implicitly marking parameter $count as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 7678

Deprecated: voku\helper\UTF8::str_slice(): Implicitly marking parameter $end as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 7913

Deprecated: voku\helper\UTF8::str_titleize(): Implicitly marking parameter $ignore as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 8704

Deprecated: voku\helper\UTF8::str_titleize(): Implicitly marking parameter $lang as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 8704

Deprecated: voku\helper\UTF8::str_titleize(): Implicitly marking parameter $word_define_chars as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 8704

Deprecated: voku\helper\UTF8::str_to_lines(): Implicitly marking parameter $remove_short_values as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 9064

Deprecated: voku\helper\UTF8::str_to_words(): Implicitly marking parameter $remove_short_values as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 9111

Deprecated: voku\helper\UTF8::str_upper_camelize(): Implicitly marking parameter $lang as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 9352

Deprecated: voku\helper\UTF8::strcspn(): Implicitly marking parameter $length as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 9515

Deprecated: voku\helper\UTF8::strip_tags(): Implicitly marking parameter $allowable_tags as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 9652

Deprecated: voku\helper\UTF8::strspn(): Implicitly marking parameter $length as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 11118

Deprecated: voku\helper\UTF8::strtocasefold(): Implicitly marking parameter $lang as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 11348

Deprecated: voku\helper\UTF8::strtolower(): Implicitly marking parameter $lang as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 11403

Deprecated: voku\helper\UTF8::strtoupper(): Implicitly marking parameter $lang as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 11483

Deprecated: voku\helper\UTF8::substr(): Implicitly marking parameter $length as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 11698

Deprecated: voku\helper\UTF8::substr_compare(): Implicitly marking parameter $length as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 11868

Deprecated: voku\helper\UTF8::substr_count(): Implicitly marking parameter $length as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 11926

Deprecated: voku\helper\UTF8::substr_count_in_byte(): Implicitly marking parameter $length as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 12018

Deprecated: voku\helper\UTF8::substr_in_byte(): Implicitly marking parameter $length as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 12172

Deprecated: voku\helper\UTF8::titlecase(): Implicitly marking parameter $lang as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 12566

Deprecated: voku\helper\UTF8::trim(): Implicitly marking parameter $chars as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 12984

Deprecated: voku\helper\UTF8::ucfirst(): Implicitly marking parameter $lang as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 13030

Deprecated: voku\helper\UTF8::wordwrap_per_line(): Implicitly marking parameter $delimiter as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 13496

Deprecated: voku\helper\UTF8::reduce_string_array(): Implicitly marking parameter $remove_short_values as nullable is deprecated, the explicit nullable type must be used instead in voku\portable-utf8\src\voku\helper\UTF8.php on line 13827
```

Proposed Changes
avoid deprecation with PHP 8.4
